### PR TITLE
Add Fallback mode for curses

### DIFF
--- a/1.20.1/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.20.1/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -46,7 +46,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents && contents.getKey().startsWith("enchantment.")) {
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents && contents.getKey().startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Enchantment enchantment = null;
                 if (enchantmentKey.length >= 3) {
@@ -65,6 +66,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.20.1/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.20.1/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.20.4/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.20.4/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -50,7 +50,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents &&
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents &&
                     contents.getKey().startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Enchantment enchantment = null;
@@ -70,6 +71,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.20.4/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.20.4/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.21.1/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.21.1/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -59,7 +59,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents &&
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents &&
                     contents.getKey().startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Holder<Enchantment> enchantment = null;
@@ -80,6 +81,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.21.1/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.21.1/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.21.10/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.21.10/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -64,7 +64,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents && contents.getKey()
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents && contents.getKey()
                     .startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Holder<Enchantment> enchantment = null;
@@ -87,6 +88,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.21.10/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.21.10/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.21.11/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.21.11/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -64,7 +64,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents && contents.getKey()
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents && contents.getKey()
                     .startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Holder<Enchantment> enchantment = null;
@@ -87,6 +88,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.21.11/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.21.11/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.21.3/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.21.3/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -63,7 +63,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents &&
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents &&
                     contents.getKey().startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Holder<Enchantment> enchantment = null;
@@ -86,6 +87,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.21.3/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.21.3/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.21.4/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.21.4/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -63,7 +63,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents &&
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents &&
                     contents.getKey().startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Holder<Enchantment> enchantment = null;
@@ -86,6 +87,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.21.4/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.21.4/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.21.5/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.21.5/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -63,7 +63,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents &&
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents &&
                     contents.getKey().startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Holder<Enchantment> enchantment = null;
@@ -86,6 +87,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.21.5/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.21.5/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")

--- a/1.21.7/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
+++ b/1.21.7/Common/src/main/java/fuzs/sneakycurses/client/handler/ItemTooltipHandler.java
@@ -63,7 +63,8 @@ public class ItemTooltipHandler {
         if (!isAffected(player, itemStack)) return;
         ListIterator<Component> iterator = lines.listIterator();
         while (iterator.hasNext()) {
-            if (iterator.next().getContents() instanceof TranslatableContents contents &&
+            Component componentLine = iterator.next();
+            if (componentLine.getContents() instanceof TranslatableContents contents &&
                     contents.getKey().startsWith("enchantment.")) {
                 String[] enchantmentKey = contents.getKey().split("\\.");
                 Holder<Enchantment> enchantment = null;
@@ -86,6 +87,14 @@ public class ItemTooltipHandler {
                         iterator.remove();
                     }
                 }
+            }
+            // fallback mode for non-translatable curses
+            else if (SneakyCurses.CONFIG.get(ServerConfig.class).fallbackMode &&
+                        componentLine.getString().startsWith("Curse of"))
+            {
+                initSeed(currentScreenSeed + componentLine.getString().substring(9).hashCode());
+                Component component = getLoreForWidth(Minecraft.getInstance().font);
+                iterator.set(Component.empty().append(component).withStyle(ChatFormatting.RED));
             }
         }
     }

--- a/1.21.7/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
+++ b/1.21.7/Common/src/main/java/fuzs/sneakycurses/config/ServerConfig.java
@@ -6,6 +6,8 @@ import fuzs.puzzleslib.api.config.v3.ConfigCore;
 public class ServerConfig implements ConfigCore {
     @Config(name = "obfuscate_curses_on_tooltips", description = "Obfuscate curse enchantments with enchantment runes on item tooltips.")
     public boolean obfuscateCurses = true;
+    @Config(name = "fallback_mode", description = "Allow better support for mods that do not register curses with translatable text (Experimental!)")
+    public boolean fallbackMode = false;
     @Config(name = "tint_enchantment_glint_when_cursed", description = "Tint the enchantment glint in a red shade when the item is enchanted with curses.")
     public boolean cursedItemGlint = true;
     @Config(description = "Obfuscate curses on enchanted books.")


### PR DESCRIPTION
This will allow curses from other mods/datapacks that do not have translatable names to be obfuscated. This is done by searching for the start of the string for the text "Curse of". I added a config with default false to enable this feature. Implemented on all version of this branch